### PR TITLE
fix: gender neutral title

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Awesome Software Craftsmanship [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)](https://github.com/sindresorhus/awesome)
+# Awesome Software Craft [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)](https://github.com/sindresorhus/awesome)
 
 > "As aspiring Software Craftsmen we are raising the bar of professional software development by **practicing it** and **helping others learn the craft**", [The software craftsmanship manifesto](http://manifesto.softwarecraftsmanship.org)
 


### PR DESCRIPTION
While I understand that the term "Software Craftsmanship" has been used for years, and conveys a rich meaning, I think that being gender neutral would make our community more inclusive and welcoming for people who are not male. (cf the "Software Crafters" section of https://qz.com/work/1371151/what-happened-to-software-craftsmanship/)

If you agree with this suggestion, I also propose to rename the repository accordingly. FYI: normally, GitHub will automatically redirect visitors from the old URLs to the updated ones, so no link to your repo should be broken.

My intention is not at all to start a debate. Feel free to accept or discard this PR, I will not judge your decision either way, and hope that nobody else will. This is your repository, so you are free to do whatever you want with it. :-)